### PR TITLE
Serializable types

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-dataclasses-json

--- a/typedflow/typedflow.py
+++ b/typedflow/typedflow.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Generic, Generator, List, Type, TypeVar
 
-from dataclasses_json import dataclass_json
-
 
 T = TypeVar('T')  # serializable
 K = TypeVar('K')  # serializable
 
 
-@dataclass_json
 @dataclass
 class Batch(Generic[T]):
     batch_id: int


### PR DESCRIPTION
Python doesn't offer the serializable type class. Here are some ideas:

- Make an original type class whose instances (i.e. classes) have `dump()` methods.
- Implement a runtime validation to assert each method is serializable.

I prefer the former idea.