### PR TITLE
Inadequate type assignment

### DIFF
--- a/typedflow/tests/typedflow/test_task.py
+++ b/typedflow/tests/typedflow/test_task.py
@@ -1,18 +1,22 @@
+from typing import List
 import unittest
 
-from typedflow.typedflow import T, K, Task, Pipeline
+from typedflow.typedflow import (
+    Task, Pipeline, DataLoader, Dumper
+)
 
 
 class TaskTest(unittest.TestCase):
+
     def setUp(self):
         data: List[str] = [
             'This is a test.',
             'Here we are.',
         ]
-        loader: DataLoader[str] = self.DataLoader(gen=data)
+        loader: DataLoader[str] = DataLoader(gen=data)
         count_word: Task[str, int] = Task[str, int](lambda s: len(s))
         convert_to_str: Task[int, str] = Task[int, str](lambda x: str(x))
-        dumpler: Dumper[str] = Dumper[str](print)
+        dumper: Dumper[str] = Dumper[str](print)
         self.pipeline: Pipeline = Pipeline(
             loader, [count_word, convert_to_str, ], dumper)
 


### PR DESCRIPTION
```python
assert self.loader.out_type == self.pipeline[0].in_type
```
fails due to statements like this:
```python
class A(Generic[T]):
    something: Type = T
```